### PR TITLE
Add featureCounts and HTSeq quantification options

### DIFF
--- a/modules/quantification/featurecounts.nf
+++ b/modules/quantification/featurecounts.nf
@@ -1,0 +1,48 @@
+/*
+ * FEATURECOUNTS
+ *
+ * Count reads mapping to genomic features using featureCounts (Subread).
+ * featureCounts is fast and memory-efficient, making it ideal for
+ * large-scale RNA-seq experiments.
+ *
+ * Input:
+ *   - bam_files: Collection of sorted BAM files
+ *   - gtf: GTF annotation file
+ *
+ * Output:
+ *   - counts: Gene count matrix
+ *   - summary: Assignment summary statistics
+ *
+ * Tools: featureCounts (http://subread.sourceforge.net/)
+ */
+
+process FEATURECOUNTS {
+    tag "featureCounts"
+    label 'process_medium'
+
+    publishDir "${params.outdir}/featurecounts", mode: 'copy'
+
+    input:
+    path(bam_files)
+    path(gtf)
+
+    output:
+    path("featurecounts.txt"), emit: counts
+    path("featurecounts.txt.summary"), emit: summary
+
+    script:
+    def threads = task.cpus ?: params.threads ?: 8
+    // Strandedness: 0 = unstranded, 1 = stranded, 2 = reversely stranded
+    def strandedness = params.strandedness ?: 0
+    """
+    featureCounts \\
+        -T ${threads} \\
+        -p \\
+        -t exon \\
+        -g gene_id \\
+        -s ${strandedness} \\
+        -a ${gtf} \\
+        -o featurecounts.txt \\
+        ${bam_files}
+    """
+}

--- a/modules/quantification/htseq.nf
+++ b/modules/quantification/htseq.nf
@@ -1,0 +1,93 @@
+/*
+ * HTSEQ_COUNT
+ *
+ * Count reads mapping to genomic features using HTSeq-count.
+ * HTSeq is widely used and produces results compatible with
+ * DESeq2 and edgeR.
+ *
+ * Note: HTSeq processes one BAM at a time, so this runs per-sample.
+ *
+ * Input:
+ *   - sample_id: Sample identifier
+ *   - bam: Sorted BAM file
+ *   - bai: BAM index file
+ *   - gtf: GTF annotation file
+ *
+ * Output:
+ *   - counts: Per-sample gene counts
+ *
+ * Tools: HTSeq (https://htseq.readthedocs.io/)
+ */
+
+process HTSEQ_COUNT {
+    tag "${sample_id}"
+    label 'process_medium'
+
+    publishDir "${params.outdir}/htseq", mode: 'copy'
+
+    input:
+    tuple val(sample_id), path(bam), path(bai), path(gtf)
+
+    output:
+    path("${sample_id}.htseq.txt"), emit: counts
+
+    script:
+    // Strandedness: yes, no, reverse
+    def strand = params.strandedness == 1 ? 'yes' : (params.strandedness == 2 ? 'reverse' : 'no')
+    """
+    htseq-count \\
+        -f bam \\
+        -r pos \\
+        -s ${strand} \\
+        -t exon \\
+        -i gene_id \\
+        ${bam} \\
+        ${gtf} > ${sample_id}.htseq.txt
+    """
+}
+
+/*
+ * HTSEQ_MERGE
+ *
+ * Merge individual HTSeq count files into a single count matrix.
+ *
+ * Input:
+ *   - count_files: Collection of per-sample HTSeq count files
+ *
+ * Output:
+ *   - merged_counts: Combined count matrix
+ */
+
+process HTSEQ_MERGE {
+    tag "merge_htseq"
+    label 'process_low'
+
+    publishDir "${params.outdir}/htseq", mode: 'copy'
+
+    input:
+    path(count_files)
+
+    output:
+    path("htseq_counts.txt"), emit: merged_counts
+
+    script:
+    """
+    # Get gene IDs from first file (excluding summary lines starting with __)
+    head -1 *.htseq.txt | cut -f1 | grep -v "^__" > genes.txt || true
+
+    # Create header
+    echo -n "gene_id" > htseq_counts.txt
+    for f in *.htseq.txt; do
+        sample=\$(basename \$f .htseq.txt)
+        echo -ne "\\t\${sample}" >> htseq_counts.txt
+    done
+    echo "" >> htseq_counts.txt
+
+    # Merge counts (exclude summary lines)
+    paste *.htseq.txt | grep -v "^__" | awk '{
+        printf \$1
+        for (i=2; i<=NF; i+=2) printf "\\t"\$i
+        print ""
+    }' >> htseq_counts.txt
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,11 @@ params {
     skip_rseqc      = false
     save_trimmed    = true
     save_aligned    = true
+
+    // Quantification options
+    run_featurecounts = false
+    run_htseq         = false
+    strandedness      = 0       // 0=unstranded, 1=stranded, 2=reversely stranded
 }
 
 // Process-specific resource requirements
@@ -136,7 +141,7 @@ profiles {
         process.queue          = 'defq'
         process.clusterOptions = '--account=arbya'
     // ADD THIS: Load the required software modules before running the task
-        process.beforeScript   = 'module load hisat2/2.2.1 samtools/1.21 stringtie/3.0.0 FastQC/0.12.0 TrimGalore/0.6.10 rseqc/5.0.4 ucsc-tools/latest'
+        process.beforeScript   = 'module load hisat2/2.2.1 samtools/1.21 stringtie/3.0.0 FastQC/0.12.0 TrimGalore/0.6.10 rseqc/5.0.4 ucsc-tools/latest subread htseq'
     }
 
     // PBS/Torque cluster execution

--- a/params.yaml
+++ b/params.yaml
@@ -90,6 +90,21 @@ outdir: "/home/arbya/wrk/cat_fas_project/bulk_rnaseq_analysis_apr2026/ensembl_re
 skip_rseqc: false
 
 # -----------------------------------------------------------------------------
+# QUANTIFICATION OPTIONS
+# -----------------------------------------------------------------------------
+# By default, StringTie quantification is always run.
+# Enable featureCounts and/or HTSeq for alternative count matrices.
+
+run_featurecounts: false    # Set to true to run featureCounts (Subread)
+run_htseq: false            # Set to true to run HTSeq-count
+
+# Strandedness for featureCounts/HTSeq:
+#   0 = unstranded
+#   1 = stranded (sense)
+#   2 = reversely stranded (antisense, e.g. dUTP/Illumina TruSeq)
+strandedness: 0
+
+# -----------------------------------------------------------------------------
 # RESOURCE SETTINGS
 # -----------------------------------------------------------------------------
 threads: 8

--- a/workflows/main.nf
+++ b/workflows/main.nf
@@ -13,7 +13,8 @@
  *   7. Merge transcript assemblies (StringTie merge)
  *   8. Quantification (StringTie - second pass)
  *   9. Prepare count matrices (prepDE.py)
- *  10. MultiQC report generation
+ *  10. featureCounts / HTSeq quantification (optional)
+ *  11. MultiQC report generation
  */
 
 nextflow.enable.dsl = 2
@@ -35,6 +36,9 @@ include { STRINGTIE_FIRST } from '../modules/transcript_assembly/stringtie_first
 include { STRINGTIE_MERGE } from '../modules/transcript_assembly/stringtie_merge.nf'
 include { STRINGTIE_SECOND } from '../modules/transcript_assembly/stringtie_second.nf'
 include { PREPDE } from '../modules/transcript_assembly/prepde.nf'
+include { FEATURECOUNTS } from '../modules/quantification/featurecounts.nf'
+include { HTSEQ_COUNT } from '../modules/quantification/htseq.nf'
+include { HTSEQ_MERGE } from '../modules/quantification/htseq.nf'
 include { MULTIQC } from '../modules/qc/multiqc.nf'
 
 /*
@@ -171,7 +175,36 @@ workflow {
     )
 
     /*
-     * STEP 12: Generate MultiQC report
+     * STEP 12: featureCounts quantification (optional)
+     * Fast read counting using Subread featureCounts
+     */
+    if (params.run_featurecounts) {
+        // Collect all sorted BAM files
+        bam_files_ch = SAMTOOLS_SORT.out.sorted_bam
+            .map { sample_id, bam, bai -> bam }
+            .collect()
+
+        FEATURECOUNTS(bam_files_ch, file(params.gtf_annotation))
+    }
+
+    /*
+     * STEP 13: HTSeq quantification (optional)
+     * Read counting using HTSeq-count
+     */
+    if (params.run_htseq) {
+        // Run HTSeq per sample
+        HTSEQ_COUNT(
+            SAMTOOLS_SORT.out.sorted_bam.combine(gtf_annotation_ch)
+        )
+
+        // Merge individual count files into a matrix
+        HTSEQ_MERGE(
+            HTSEQ_COUNT.out.counts.collect()
+        )
+    }
+
+    /*
+     * STEP 14: Generate MultiQC report
      * Collect QC outputs from Trim Galore, HISAT2, SAMtools, StringTie, and RSeQC
      */
     qc_files_ch = TRIM_GALORE.out.qc_reports
@@ -190,6 +223,11 @@ workflow {
             .mix(RSEQC_GENE_BODY_COVERAGE.out.coverage)
             .mix(RSEQC_TIN.out.tin_scores)
             .mix(RSEQC_TIN.out.summary)
+    }
+
+    // Add featureCounts summary to MultiQC if run
+    if (params.run_featurecounts) {
+        qc_files_ch = qc_files_ch.mix(FEATURECOUNTS.out.summary)
     }
 
     MULTIQC(qc_files_ch.collect())


### PR DESCRIPTION
New modules:
- modules/quantification/featurecounts.nf: Fast read counting with Subread
- modules/quantification/htseq.nf: HTSeq-count with merge step

New parameters:
- run_featurecounts: Enable featureCounts (default: false)
- run_htseq: Enable HTSeq-count (default: false)
- strandedness: 0=unstranded, 1=stranded, 2=reverse (default: 0)

Module loads updated: added subread and htseq

StringTie quantification still runs by default. featureCounts and HTSeq are optional alternatives that can be enabled in params.yaml.

https://claude.ai/code/session_01S9TRwCfH2QWkjWHiYtBK5j