### PR TITLE
Add Docker support and containerization for bulk-rnaseq-nf pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'environment.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Dockerfile for bulk-rnaseq-nf pipeline
+# Build: docker build -t bulk-rnaseq-nf .
+# Run with Nextflow: nextflow run workflows/main.nf -params-file params.yaml -profile docker
+
+FROM mambaorg/micromamba:1.5-jammy
+
+LABEL maintainer="RNA-seq Pipeline Authors"
+LABEL description="Docker container for bulk-rnaseq-nf Nextflow pipeline"
+LABEL version="1.0.0"
+
+# Copy environment definition
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
+
+# Install all dependencies via micromamba
+RUN micromamba install -y -n base -f /tmp/environment.yml && \
+    micromamba clean --all --yes
+
+# Ensure conda environment is activated
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+# Verify key tools are available
+RUN hisat2 --version && \
+    samtools --version | head -1 && \
+    stringtie --version && \
+    trim_galore --version && \
+    fastqc --version && \
+    multiqc --version && \
+    featureCounts -v 2>&1 | head -1 && \
+    python --version
+
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -61,23 +61,60 @@ Or ensure the following tools are in your PATH:
 
 ## Installation
 
-### Option 1: HPC Cluster with Module System
+### Option 1: Docker (Recommended)
+
+The easiest way to run the pipeline with all dependencies pre-installed. Requires [Docker](https://docs.docker.com/get-docker/) and [Nextflow](https://www.nextflow.io/).
+
+```bash
+# Clone the repository
+git clone https://github.com/aa9gj/bulk-rnaseq-nf.git
+cd bulk-rnaseq-nf
+
+# Run with the Docker profile (image is pulled automatically)
+nextflow run workflows/main.nf -params-file params.yaml -profile docker
+```
+
+The Docker image is hosted on GitHub Container Registry and will be pulled automatically on the first run. To pull it manually:
+
+```bash
+docker pull ghcr.io/aa9gj/bulk-rnaseq-nf:latest
+```
+
+To build the image locally instead:
+
+```bash
+docker build -t bulk-rnaseq-nf .
+```
+
+### Option 2: Singularity
+
+For HPC environments where Docker is not available, use Singularity (which can pull Docker images):
+
+```bash
+git clone https://github.com/aa9gj/bulk-rnaseq-nf.git
+cd bulk-rnaseq-nf
+
+# Run with Singularity profile (image is pulled automatically)
+nextflow run workflows/main.nf -params-file params.yaml -profile singularity
+```
+
+### Option 3: HPC Cluster with Module System
 
 If your cluster has the required software installed as modules, simply use the SLURM profile:
 
 ```bash
-git clone https://github.com/yourusername/bulk-rnaseq-nf.git
+git clone https://github.com/aa9gj/bulk-rnaseq-nf.git
 cd bulk-rnaseq-nf
 
 # Run with SLURM profile (modules loaded automatically)
 nextflow run workflows/main.nf -params-file params.yaml -profile slurm
 ```
 
-### Option 2: Conda
+### Option 4: Conda
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/bulk-rnaseq-nf.git
+git clone https://github.com/aa9gj/bulk-rnaseq-nf.git
 cd bulk-rnaseq-nf
 
 # Install dependencies with conda

--- a/nextflow.config
+++ b/nextflow.config
@@ -118,6 +118,7 @@ profiles {
         docker.userEmulation   = true
         singularity.enabled    = false
         podman.enabled         = false
+        process.container      = 'ghcr.io/aa9gj/bulk-rnaseq-nf:latest'
     }
 
     // Singularity container support
@@ -126,6 +127,7 @@ profiles {
         singularity.autoMounts = true
         docker.enabled         = false
         podman.enabled         = false
+        process.container      = 'ghcr.io/aa9gj/bulk-rnaseq-nf:latest'
     }
 
     // Conda environment support


### PR DESCRIPTION
## Summary
This PR adds comprehensive Docker containerization support to the bulk-rnaseq-nf pipeline, enabling easier deployment and reproducibility across different environments.

## Key Changes

- **Added Dockerfile**: Created a containerized environment based on `mambaorg/micromamba:1.5-jammy` that installs all pipeline dependencies from `environment.yml`. Includes verification steps to ensure all key tools (hisat2, samtools, stringtie, trim_galore, fastqc, multiqc, featureCounts) are properly installed.

- **Added GitHub Actions CI/CD workflow**: Implemented `.github/workflows/docker-publish.yml` to automatically build and push Docker images to GitHub Container Registry (ghcr.io) on:
  - Pushes to main branch (when Dockerfile or environment.yml changes)
  - Release publications
  - Manual workflow dispatch
  - Generates tags for `latest`, semantic versions, and commit SHA

- **Updated Nextflow configuration**: Modified `nextflow.config` to specify the Docker image (`ghcr.io/aa9gj/bulk-rnaseq-nf:latest`) for both docker and singularity profiles, enabling automatic image pulling.

- **Updated documentation**: Reorganized README.md installation instructions to prioritize Docker as the recommended option, with clear instructions for:
  - Running with Docker (automatic image pull)
  - Manual Docker image building
  - Singularity support for HPC environments
  - Existing SLURM and Conda options

## Notable Implementation Details

- The Docker image is automatically built and published to GitHub Container Registry, making it accessible without local building
- Singularity profile also uses the same Docker image, providing flexibility for HPC environments
- The workflow uses GitHub Actions cache for faster builds
- All installation steps are verified in the Dockerfile to catch issues early

https://claude.ai/code/session_01P7kX2qLKovcM3fdGd7rpq3